### PR TITLE
Centralize GPS/IMU serial config and update localization Docker support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ set(ROVER_PACKAGES
     rospy                 # For writing Python nodes if needed.
     std_msgs              # Provides standard message types.
     sensor_msgs           # Provides sensor message types (e.g., for IMU/GPS data).
+    gps_common            # Provides GPS-related ROS messages such as GPSFix used by our GPS node.
+    robot_localization    # Provides EKF/UKF-based state estimation and sensor fusion for robot pose.
     message_generation    # Needed only if you create custom messages.
 )
 # If you are using custom messages in your package, list the message files here.
@@ -50,6 +52,8 @@ set(ROVER_CATKIN_PACKAGES
     roscpp
     rospy
     std_msgs
+    gps_common           # Provides GPS-related ROS messages such as GPSFix used by our GPS node.
+    robot_localization   # Provides EKF/UKF-based state estimation and sensor fusion for robot pose.
     message_runtime      # Required if using custom messages.
 )
 # ------------------------------------------------------------------------------
@@ -61,7 +65,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 # Ucomment only if you're writing Python code that should be imported like a library, e.g.: from uvic_rover.nav import gps_utils
 # Note: requires a setup.py file to be preset.
-# catkin_python_setup()
+catkin_python_setup()
 # ------------------------------------------------------------------------------
 # 4. Message Generation (Optional)
 # ------------------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL >> /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
+# Allow non-root user to access serial devices like /dev/ttyACM0
+RUN usermod -aG dialout,plugdev $USERNAME
+
 # Set up environment variables for ROS
 RUN echo "source /opt/ros/noetic/setup.bash" >> /root/.bashrc \
     && echo "source /opt/ros/noetic/setup.bash" >> /home/$USERNAME/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,83 +2,151 @@
 # Development Image
 #########################################################
 
-# Base image: Ubuntu 20.04
+# Full ROS Noetic desktop image on Ubuntu 20.04.
+# Used for local development, including GUI tools like RViz/rqt.
 FROM osrf/ros:noetic-desktop-full AS dev
 
 LABEL maintainer="UVic Robotics <uvic.robotics@gmail.com>"
-# Avoid interactive prompts during apt installs
+
+# Avoid interactive prompts during apt installs.
 ARG DEBIAN_FRONTEND=noninteractive
 
-# Basic dev tools
+# Basic dev tools + ROS development dependencies
+#
+# nano: simple terminal text editor.
+# vim: more powerful terminal text editor.
+# curl: downloads files/data from URLs.
+# git: version control for the repo.
+# git-lfs: handles large files tracked through Git LFS.
+# python3-pip: installs Python packages from requirements.txt.
+# build-essential: provides compilers and build tools like gcc, g++, and make.
+# lsb-release: lets scripts check Ubuntu/Linux distribution info.
+# gnupg2: manages package signing keys for apt repositories.
+# sudo: allows the non-root dev user to run admin commands.
+# iproute2: provides `ip`, useful for debugging WSL/Docker networking and display routing.
+# x11-apps: provides GUI test tools like `xeyes`.
+# mesa-utils: provides OpenGL test/debug tools like `glxinfo` and `glxgears`.
+# libgl1-mesa-glx: provides OpenGL libraries needed by GUI tools such as RViz.
+# ros-noetic-gps-common: provides GPS-related ROS message types/utilities.
+# ros-noetic-robot-localization: provides EKF/UKF localization and navsat_transform_node.
 RUN apt-get update && apt-get install -y \
-    nano vim curl git git-lfs python3-pip build-essential \
-    lsb-release gnupg2 sudo \
-    x11-apps mesa-utils libgl1-mesa-glx \
+    nano \
+    vim \
+    curl \
+    git \
+    git-lfs \
+    python3-pip \
+    build-essential \
+    lsb-release \
+    gnupg2 \
+    sudo \
+    iproute2 \
+    x11-apps \
+    mesa-utils \
+    libgl1-mesa-glx \
+    ros-noetic-gps-common \
+    ros-noetic-robot-localization \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies for ROS nodes (pip requirements)
+# Install Python dependencies used by ROS Python nodes.
 COPY requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install --no-cache-dir -r /tmp/requirements.txt
 
-
-# Create a non-root user
+# Create a non-root user for normal development.
+# This avoids editing/building everything as root inside the container.
 ARG USERNAME=ros
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    && mkdir /home/$USERNAME/.config && chown $USER_UID:$USER_GID /home/$USERNAME/.config \
+    && mkdir /home/$USERNAME/.config \
+    && chown $USER_UID:$USER_GID /home/$USERNAME/.config \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL >> /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME
 
-# Allow non-root user to access serial devices like /dev/ttyACM0
+# Add the dev user to hardware-access groups.
+# dialout: allows access to serial devices like /dev/ttyUSB0 and /dev/ttyACM0.
+# plugdev: commonly used for removable/plugged-in device permissions.
 RUN usermod -aG dialout,plugdev $USERNAME
 
-# Set up environment variables for ROS
+# Configure every new terminal for ROS development.
+# This sources ROS Noetic, sources the Catkin workspace when it exists,
+# sets safe localhost defaults for ROS networking, and wraps catkin_make
+# so a successful build is immediately sourced in the current terminal.
 RUN echo "source /opt/ros/noetic/setup.bash" >> /root/.bashrc \
-    && echo "source /opt/ros/noetic/setup.bash" >> /home/$USERNAME/.bashrc
+    && { \
+        echo ""; \
+        echo "# ROS auto-setup"; \
+        echo "if [ -f /opt/ros/noetic/setup.bash ]; then"; \
+        echo "  source /opt/ros/noetic/setup.bash"; \
+        echo "fi"; \
+        echo ""; \
+        echo "if [ -f /catkin_ws/devel/setup.bash ]; then"; \
+        echo "  source /catkin_ws/devel/setup.bash"; \
+        echo "fi"; \
+        echo ""; \
+        echo "export ROS_MASTER_URI=\"\${ROS_MASTER_URI:-http://localhost:11311}\""; \
+        echo "export ROS_HOSTNAME=\"\${ROS_HOSTNAME:-localhost}\""; \
+        echo ""; \
+        echo "# Wrapper: after catkin_make succeeds, source the workspace in this terminal"; \
+        echo "catkin_make() {"; \
+        echo "  command catkin_make \"\$@\""; \
+        echo "  local status=\$?"; \
+        echo "  if [ \$status -eq 0 ] && [ -f /catkin_ws/devel/setup.bash ]; then"; \
+        echo "    source /catkin_ws/devel/setup.bash"; \
+        echo "  fi"; \
+        echo "  return \$status"; \
+        echo "}"; \
+    } >> /home/$USERNAME/.bashrc
 
-# Switch to non-root user and setup workspace
+# Switch to the non-root development user and create the Catkin workspace.
 USER $USERNAME
 WORKDIR /catkin_ws
 RUN mkdir -p src
 
-# Default command
+# Start an interactive shell by default.
 CMD ["/bin/bash"]
 
 #########################################################
 # CI/CD Image
 #########################################################
+
+# Smaller ROS base image used for automated builds.
+# This stage intentionally excludes GUI/editor/debug tools from the dev image.
 FROM ros:noetic-ros-base AS ci
 
-LABEL maintainer="UVicRobotics <uvic.robotics@gmail.com>"
-# Prevent interactive prompts during apt installations
+LABEL maintainer="UVic Robotics <uvic.robotics@gmail.com>"
+
+# Avoid interactive prompts during apt installs.
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install minimal tools + runtime dependencies
+# Install only the tools and ROS dependencies needed to build/test in CI.
+# --no-install-recommends keeps the CI image smaller by avoiding optional packages.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git python3-pip \
+    git \
+    python3-pip \
     ros-noetic-gps-common \
     ros-noetic-robot-localization \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies for ROS nodes (pip requirements)
+# Install Python dependencies used by ROS Python nodes.
 COPY requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install --no-cache-dir -r /tmp/requirements.txt
 
-# Create the catkin workspace directory
+# Create the Catkin workspace directory.
 RUN mkdir -p /catkin_ws/src
 WORKDIR /catkin_ws
 
-# Copy source code
+# Copy the repository into the CI workspace.
 COPY . src/uvic_rover/
 
-# Install dependencies listed in package.xml for all packages in the src 
+# Install ROS package dependencies declared in package.xml files.
 RUN rosdep update && \
     rosdep install --from-paths src --ignore-src -r -y
 
-# Build the catkin workspace
+# Build the Catkin workspace.
 RUN /bin/bash -c "source /opt/ros/noetic/setup.bash && catkin_make"
 
+# Start a shell with the built workspace sourced.
 CMD ["/bin/bash", "-c", "source /catkin_ws/devel/setup.bash && bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,11 @@ RUN apt-get update && apt-get install -y \
     x11-apps mesa-utils libgl1-mesa-glx \
     && rm -rf /var/lib/apt/lists/*
 
+# Install Python dependencies for ROS nodes (pip requirements)
+COPY requirements.txt /tmp/requirements.txt
+RUN python3 -m pip install --no-cache-dir -r /tmp/requirements.txt
+
+
 # Create a non-root user
 ARG USERNAME=ros
 ARG USER_UID=1000
@@ -54,6 +59,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ros-noetic-gps-common \
     ros-noetic-robot-localization \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies for ROS nodes (pip requirements)
+COPY requirements.txt /tmp/requirements.txt
+RUN python3 -m pip install --no-cache-dir -r /tmp/requirements.txt
 
 # Create the catkin workspace directory
 RUN mkdir -p /catkin_ws/src

--- a/config/serial_ports.yaml
+++ b/config/serial_ports.yaml
@@ -1,0 +1,20 @@
+serial_ports:
+  imu:
+    name: "IMU"
+    port: "/dev/ttyACM0"
+    baud: 115200
+    timeout: 0.1
+    vidpids:
+      - "239a:8120"
+    allow_single_port_fallback: false
+    rosrun_hint: "rosrun uvic_rover imu.py _port:=/dev/ttyACM0"
+
+  gps:
+    name: "GPS"
+    port: "/dev/ttyUSB0"
+    baud: 9600
+    timeout: 10.0
+    vidpids:
+      - "10c4:ea60"
+    allow_single_port_fallback: false
+    rosrun_hint: "rosrun uvic_rover gps.py _port:=/dev/ttyUSB0"

--- a/launch/bringup.launch
+++ b/launch/bringup.launch
@@ -1,20 +1,23 @@
 <launch>
-  <!-- 1) Sensor drivers -->
+  <!-- 1) Loaded parameters -->
+  <rosparam command="load" file="$(find uvic_rover)/config/serial_ports.yaml" />
+
+  <!-- 2) Sensor drivers -->
   <node pkg="uvic_rover" type="imu.py" name="imu_node" output="screen"/>
   <node pkg="uvic_rover" type="gps.py" name="gps_node" output="screen"/>
 
-  <!-- 2) Static TFs -->
+  <!-- 3) Static TFs -->
   <include file="$(find uvic_rover)/launch/robot_description.launch"/>
 
-  <!-- 3) Local EKF -->
+  <!-- 4) Local EKF -->
   <include file="$(find uvic_rover)/launch/ekf_local.launch"/>
 
-  <!-- 4) NavSat transform -->
+  <!-- 5) NavSat transform -->
   <include file="$(find uvic_rover)/launch/navsat_transform.launch"/>
 
-  <!-- 5) Global EKF -->
+  <!-- 6) Global EKF -->
   <include file="$(find uvic_rover)/launch/ekf_global.launch"/>
 
-  <!-- 6) (Optional) RViz -->
+  <!-- 7) (Optional) RViz -->
   <!-- … -->
 </launch>

--- a/nodes/odom/gps.py
+++ b/nodes/odom/gps.py
@@ -6,6 +6,7 @@ from sensor_msgs.msg import NavSatFix
 from gps_common.msg import GPSFix
 import serial
 import serial.tools.list_ports
+from uvic_rover.serial_utils import open_serial_port
 # Create a serial connection for the GPS connection using default speed and
 # a slightly higher timeout (GPS modules typically update once a second).
 # These are the defaults you should use for the GPS FeatherWing.
@@ -13,19 +14,6 @@ import serial.tools.list_ports
 #uart = busio.UART(board.TX, board.RX, baudrate=9600, timeout=10)
 
 # for a computer, use the pyserial library for uart access
-
-def find_gps_port():
-    # Iterate over all available serial ports
-    ports = list(serial.tools.list_ports.comports())
-    for port in ports:
-        #print(f"DEBUG: Device: {port.device}, VID: {port.vid}, PID: {port.pid}, Description: {port.description}")
-        # Check if the port has the desired vendor and product ID
-        if port.vid == 0x10c4 and port.pid == 0xea60: # If correct GPS
-            rospy.loginfo(f"GPS device found on {port.device}")
-            return serial.Serial(port.device, baudrate=9600, timeout=10)      
-    rospy.logfatal("GPS device not found!")
-    rospy.signal_shutdown("GPS device not found!")
-    raise rospy.ROSInterruptException("GPS device not found!")
 
 def main():
     # Initialize GPS Ros node 
@@ -43,7 +31,7 @@ def main():
 
     rate = rospy.Rate(1)
 
-    uart = find_gps_port()
+    uart = open_serial_port("/serial_ports/gps")
     # Create a GPS module instance.
     gps = adafruit_gps.GPS(uart, debug=False)  # Use UART/pyserial
     # gps = adafruit_gps.GPS_GtopI2C(i2c, debug=False)  # Use I2C interface
@@ -71,6 +59,7 @@ def main():
     # You can also speed up the rate, but don't go too fast or else you can lose
     # data during parsing.  This would be twice a second (2hz, 500ms delay):
     # gps.send_command(b'PMTK220,500')
+    rospy.loginfo("GPS: node initialised")
 
     # Main loop runs forever printing the location, etc. every second.
     last_print = time.monotonic()
@@ -86,7 +75,7 @@ def main():
             last_print = current
             if not gps.has_fix:
                 # Try again if we don't have a fix yet.
-                rospy.logdebug("Waiting for fix...")
+                rospy.loginfo_throttle(10, "[ODOM] GPS Waiting for fix...")
                 continue
             # We have a fix! (gps.has_fix is true)
             

--- a/nodes/odom/imu.py
+++ b/nodes/odom/imu.py
@@ -21,6 +21,14 @@ SERIAL_BAUD   = 115_200
 EXPECTED_FIELDS = 13
 DEFAULT_RATE_HZ = 50
 
+# Allowlist of known USB VID/PID pairs for the IMU serial adapter(s)
+ALLOWED_VIDPID = {
+    (ARDUINO_VID, ARDUINO_PID),
+    # Add more here if you use other adapters:
+    # (0x10C4, 0xEA60),  # Silicon Labs CP210x (common)
+    # (0x239A, 0x8120),  # Adafruit / Pico variant (example)
+}
+
 # ───────── helper functions ─────────
 def _set_diag(matrix, var_xyz):
     """Fill a 3×3 covariance array (row-major) with variances on the diagonal."""

--- a/nodes/odom/imu.py
+++ b/nodes/odom/imu.py
@@ -8,6 +8,7 @@ import math
 import numpy as np
 import serial
 import serial.tools.list_ports
+from uvic_rover.serial_utils import open_serial_port
 from typing import Tuple
 from tf.transformations import euler_from_quaternion
 
@@ -59,12 +60,12 @@ class ImuData:
 # ───────── node class ─────────
 class ImuNode:
     def __init__(self, rate_hz: int = DEFAULT_RATE_HZ) -> None:
-        self._serial = self._open_port()
+        self._serial = open_serial_port("/serial_ports/imu")
         self._pub    = rospy.Publisher("/imu/data", Imu, queue_size=10)
         self._rate   = rospy.Rate(rate_hz)
         self._data   = ImuData()
         rospy.on_shutdown(self._shutdown)
-        rospy.loginfo("IMU node initialised")
+        rospy.loginfo("IMU: node initialised")
 
     # ----- main loop -----
     def spin(self) -> None:
@@ -79,61 +80,6 @@ class ImuNode:
                 rospy.logerr_throttle(1.0, f"Serial error: {err}")
 
     # ----- serial helpers -----
-    def _open_port(self):
-        forced = rospy.get_param("~port", "").strip()
-        baud = int(rospy.get_param("~baud", SERIAL_BAUD))
-        timeout = float(rospy.get_param("~timeout", 0.1))
-
-        # 1) Explicit override (best / most deterministic)
-        if forced:
-            rospy.loginfo(f"Opening IMU on forced port: {forced} @ {baud}")
-            return serial.Serial(forced, baud, timeout=timeout)
-
-        ports = list(serial.tools.list_ports.comports())
-        if not ports:
-            rospy.logfatal(
-                "No serial ports found in this environment.\n"
-                "If you're on Windows + Docker Desktop, ensure the USB device is attached into WSL/docker."
-            )
-            rospy.signal_shutdown("No serial ports found")
-            raise rospy.ROSInterruptException
-
-        # 2) Filter by known VID/PID allowlist
-        matches = [p for p in ports if (p.vid, p.pid) in ALLOWED_VIDPID]
-
-        # Deterministic ordering
-        matches.sort(key=lambda p: p.device)
-        ports_sorted = sorted(ports, key=lambda p: p.device)
-
-        if len(matches) == 1:
-            p = matches[0]
-            rospy.loginfo(f"IMU detected on {p.device} (VID:PID={p.vid:04x}:{p.pid:04x})")
-            return serial.Serial(p.device, baud, timeout=timeout)
-
-        # 3) If only one port exists total, use it (common on dev machines)
-        if len(ports_sorted) == 1:
-            p = ports_sorted[0]
-            rospy.logwarn(f"No VID/PID match; using only available port: {p.device} ({p.description})")
-            return serial.Serial(p.device, baud, timeout=timeout)
-
-        # 4) Otherwise: ambiguous — force user to specify port
-        port_list = "\n".join(
-            [f"  - {p.device} | {p.description} | VID:PID={p.vid}:{p.pid}" for p in ports_sorted]
-        )
-        match_list = "\n".join(
-            [f"  - {p.device} | VID:PID={p.vid:04x}:{p.pid:04x}" for p in matches]
-        ) or "  (none)"
-
-        rospy.logfatal(
-            "IMU port is ambiguous.\n"
-            f"Ports seen:\n{port_list}\n"
-            f"VID/PID allowlist matches:\n{match_list}\n"
-            "Fix: pass the port explicitly, e.g.:\n"
-            "  rosrun uvic_rover imu.py _port:=/dev/ttyACM0"
-        )
-        rospy.signal_shutdown("Ambiguous serial ports")
-        raise rospy.ROSInterruptException
-
     def _read_raw_sample(self):
         line = self._serial.readline().decode(errors="ignore").strip()
         if not line:
@@ -170,12 +116,12 @@ class ImuNode:
         # angular vel
         msg.angular_velocity.x, msg.angular_velocity.y, msg.angular_velocity.z = self._data.gyro
 
-        #TEMP
-        yaw = euler_from_quaternion([msg.orientation.x,
-            msg.orientation.y,
-            msg.orientation.z,
-            msg.orientation.w])[2]
-        print(f"yaw (deg): {math.degrees(yaw):.1f}")
+        # UCOMMENT TO PRINT YAW (degrees) FOR DEBUGGING
+        # yaw = euler_from_quaternion([msg.orientation.x,
+        #     msg.orientation.y,
+        #     msg.orientation.z,
+        #     msg.orientation.w])[2]
+        # print(f"yaw (deg): {math.degrees(yaw):.1f}")
 
                 # ====== covariance values (variance, not std-dev) ======
         gyro_var   = [1.5e-6] * 3                      # rad²/s²

--- a/nodes/odom/imu.py
+++ b/nodes/odom/imu.py
@@ -72,12 +72,58 @@ class ImuNode:
 
     # ----- serial helpers -----
     def _open_port(self):
-        for port in serial.tools.list_ports.comports():
-            if port.vid == ARDUINO_VID and port.pid == ARDUINO_PID:
-                rospy.loginfo(f"IMU detected on {port.device}")
-                return serial.Serial(port.device, SERIAL_BAUD, timeout=0.1)
-        rospy.logfatal("IMU device not found")
-        rospy.signal_shutdown("IMU device not found")
+        forced = rospy.get_param("~port", "").strip()
+        baud = int(rospy.get_param("~baud", SERIAL_BAUD))
+        timeout = float(rospy.get_param("~timeout", 0.1))
+
+        # 1) Explicit override (best / most deterministic)
+        if forced:
+            rospy.loginfo(f"Opening IMU on forced port: {forced} @ {baud}")
+            return serial.Serial(forced, baud, timeout=timeout)
+
+        ports = list(serial.tools.list_ports.comports())
+        if not ports:
+            rospy.logfatal(
+                "No serial ports found in this environment.\n"
+                "If you're on Windows + Docker Desktop, ensure the USB device is attached into WSL/docker."
+            )
+            rospy.signal_shutdown("No serial ports found")
+            raise rospy.ROSInterruptException
+
+        # 2) Filter by known VID/PID allowlist
+        matches = [p for p in ports if (p.vid, p.pid) in ALLOWED_VIDPID]
+
+        # Deterministic ordering
+        matches.sort(key=lambda p: p.device)
+        ports_sorted = sorted(ports, key=lambda p: p.device)
+
+        if len(matches) == 1:
+            p = matches[0]
+            rospy.loginfo(f"IMU detected on {p.device} (VID:PID={p.vid:04x}:{p.pid:04x})")
+            return serial.Serial(p.device, baud, timeout=timeout)
+
+        # 3) If only one port exists total, use it (common on dev machines)
+        if len(ports_sorted) == 1:
+            p = ports_sorted[0]
+            rospy.logwarn(f"No VID/PID match; using only available port: {p.device} ({p.description})")
+            return serial.Serial(p.device, baud, timeout=timeout)
+
+        # 4) Otherwise: ambiguous — force user to specify port
+        port_list = "\n".join(
+            [f"  - {p.device} | {p.description} | VID:PID={p.vid}:{p.pid}" for p in ports_sorted]
+        )
+        match_list = "\n".join(
+            [f"  - {p.device} | VID:PID={p.vid:04x}:{p.pid:04x}" for p in matches]
+        ) or "  (none)"
+
+        rospy.logfatal(
+            "IMU port is ambiguous.\n"
+            f"Ports seen:\n{port_list}\n"
+            f"VID/PID allowlist matches:\n{match_list}\n"
+            "Fix: pass the port explicitly, e.g.:\n"
+            "  rosrun uvic_rover imu.py _port:=/dev/ttyACM0"
+        )
+        rospy.signal_shutdown("Ambiguous serial ports")
         raise rospy.ROSInterruptException
 
     def _read_raw_sample(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyserial
+numpy
+adafruit-circuitpython-gps

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from catkin_pkg.python_setup import generate_distutils_setup
+from distutils.core import setup
+
+setup_args = generate_distutils_setup(
+    packages=["uvic_rover"],
+    package_dir={"": "src"},
+)
+
+setup(**setup_args)

--- a/src/uvic_rover/__init__.py
+++ b/src/uvic_rover/__init__.py
@@ -1,0 +1,1 @@
+# Marks this folder as a Python package.

--- a/src/uvic_rover/serial_utils.py
+++ b/src/uvic_rover/serial_utils.py
@@ -1,0 +1,151 @@
+import os
+import yaml
+import rospkg
+import rospy
+import serial
+import serial.tools.list_ports
+
+
+def _sensor_key(config_ns):
+    return config_ns.rstrip("/").split("/")[-1]
+
+
+def _format_vidpid(port):
+    if port.vid is None or port.pid is None:
+        return "unknown"
+    return f"{port.vid:04x}:{port.pid:04x}"
+
+
+def _parse_vidpid(text):
+    vid, pid = text.split(":")
+    return int(vid, 16), int(pid, 16)
+
+
+def _load_yaml_config(config_ns):
+    sensor = _sensor_key(config_ns)
+
+    package_path = rospkg.RosPack().get_path("uvic_rover")
+    yaml_path = os.path.join(package_path, "config", "serial_ports.yaml")
+
+    if not os.path.exists(yaml_path):
+        return {}
+
+    with open(yaml_path, "r") as file:
+        data = yaml.safe_load(file) or {}
+
+    return data.get("serial_ports", {}).get(sensor, {}) or {}
+
+
+def open_serial_port(config_ns=None):
+    """
+    Open a serial device using this priority:
+
+    1. Manual private override:
+       rosrun uvic_rover imu.py _port:=/dev/ttyACM0
+
+    2. ROS params loaded from serial_ports.yaml:
+       /serial_ports/imu/port
+
+    3. Directly read config/serial_ports.yaml if params were not loaded.
+
+    4. Auto-detect by VID/PID from the config.
+
+    5. If exactly one serial port exists and fallback is enabled, use it.
+
+    6. Otherwise fail and print all detected ports.
+    """
+
+    config = {}
+
+    if config_ns and rospy.has_param(config_ns):
+        config = rospy.get_param(config_ns) or {}
+    elif config_ns:
+        config = _load_yaml_config(config_ns)
+
+    name = config.get("name", _sensor_key(config_ns).upper() if config_ns else "Serial device")
+
+    # Manual overrides always win.
+    manual_port = str(rospy.get_param("~port", "")).strip()
+    manual_baud = rospy.get_param("~baud", None)
+    manual_timeout = rospy.get_param("~timeout", None)
+
+    if manual_port:
+        port = manual_port
+        rospy.loginfo(f"{name}: using manual port override {port}")
+    else:
+        # Use configured port if present.
+        configured_port = str(config.get("port", "")).strip()
+
+        if configured_port:
+            port = configured_port
+            rospy.loginfo(f"{name}: using configured port {port}")
+        else:
+            ports = sorted(serial.tools.list_ports.comports(), key=lambda p: p.device)
+
+            if not ports:
+                rospy.logfatal(
+                    f"{name}: no serial ports found.\n"
+                    "Check that the USB device is attached into WSL/Docker."
+                )
+                rospy.signal_shutdown(f"{name} serial port not found")
+                raise rospy.ROSInterruptException
+
+            allowed_vidpids = {
+                _parse_vidpid(text)
+                for text in config.get("vidpids", [])
+            }
+
+            matches = [
+                p for p in ports
+                if p.vid is not None
+                and p.pid is not None
+                and (p.vid, p.pid) in allowed_vidpids
+            ]
+
+            if len(matches) == 1:
+                port = matches[0].device
+                rospy.loginfo(
+                    f"{name}: auto-detected on {port} "
+                    f"(VID:PID={_format_vidpid(matches[0])})"
+                )
+            elif bool(config.get("allow_single_port_fallback", True)) and len(ports) == 1:
+                port = ports[0].device
+                rospy.logwarn(
+                    f"{name}: no configured port or exact VID/PID match, "
+                    f"but only one serial port exists. Using {port}."
+                )
+            else:
+                port_list = "\n".join(
+                    f"  - {p.device} | {p.description} | VID:PID={_format_vidpid(p)}"
+                    for p in ports
+                )
+
+                match_list = "\n".join(
+                    f"  - {p.device} | {p.description} | VID:PID={_format_vidpid(p)}"
+                    for p in matches
+                ) or "  (none)"
+
+                rosrun_hint = config.get(
+                    "rosrun_hint",
+                    "rosrun uvic_rover <node>.py _port:=/dev/ttyUSB0"
+                )
+
+                rospy.logfatal(
+                    f"{name}: serial port is ambiguous.\n"
+                    f"Config namespace: {config_ns}\n"
+                    f"Ports seen:\n{port_list}\n"
+                    f"VID/PID matches:\n{match_list}\n"
+                    f"Fix: pass the port manually, e.g.:\n"
+                    f"  {rosrun_hint}"
+                )
+
+                rospy.signal_shutdown(f"{name} serial port ambiguous")
+                raise rospy.ROSInterruptException
+
+    baud = int(manual_baud if manual_baud is not None else config.get("baud", 9600))
+    timeout = float(
+        manual_timeout if manual_timeout is not None else config.get("timeout", 1.0)
+    )
+
+    rospy.loginfo(f"{name}: opening {port} @ {baud} baud, timeout={timeout}")
+    return serial.Serial(port, baudrate=baud, timeout=timeout)


### PR DESCRIPTION
This PR updates the `localization-docker` branch with the latest localization and Docker support changes so the shared serial tools can be pulled into `main` for the rest of the team.

The main goal is to make serial port handling cleaner, more configurable, and easier to reuse across nodes.

## Changes

- Modified `CMakeLists.txt` to support the updated Python node/package layout.
- Modified `Dockerfile` to improve the ROS Noetic development image and add useful dev/debug tooling.
- Added `config/serial_ports.yaml` to centralize GPS/IMU serial port configuration.
- Modified `launch/bringup.launch` to use the updated sensor/node startup flow.
- Modified `nodes/odom/gps.py` to use the shared serial port configuration/utilities.
- Modified `nodes/odom/imu.py` to use the shared serial port configuration/utilities.
- Added `setup.py` so Python modules under `src/uvic_rover` can be imported properly by ROS nodes.
- Removed obsolete `src/.gitkeep` now that `src/` contains actual package code.
- Added `src/uvic_rover/__init__.py` to define the `uvic_rover` Python package.
- Added `src/uvic_rover/serial_utils.py` for reusable serial port detection and configuration logic.

These changes make the GPS/IMU serial setup less hardcoded and easier for other developers to use. Instead of each node manually handling ports in its own way, serial configuration is now centralized through a shared YAML config file and reusable serial utility functions.

This should make future work cleaner, especially as more sensors or USB serial devices are added.

## Docker/dev environment note

This PR updates the repo's `Dockerfile`, but the actual `.devcontainer/devcontainer.json` is updated in the wiki as well: 
- Added `containerEnv` with `DISPLAY=:0.0` so ROS GUI tools use the same display number selected in VcXsrv/XLaunch.
- Added `QT_X11_NO_MITSHM=1` to help Qt-based ROS tools like `rqt_graph`, `rqt`, and RViz work more reliably through X11.
- Added comments explaining that these USB device mappings only expose devices to the container; the YAML config still tells each ROS node which port to use.
- Removed/avoided old `DISPLAY=host.docker.internal:0.0` guidance because the current tested setup uses Docker Engine inside Ubuntu WSL rather than Docker Desktop.
- Added comments explaining each major devcontainer section: image build, workspace mount, runtime environment variables, X11 GUI support, USB device mappings, and VS Code extensions.